### PR TITLE
Don't chomp context in componentWillReceiveProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "pragmatist": "^1.8.0",
     "react": "^0.14.3",
     "react-addons-test-utils": "^0.14.3",
-    "sinon": "^1.17.2"
+    "sinon": "^1.17.2",
+    "lodash": "^4.13.1"
   },
   "scripts": {
     "pragmatist": "node ./node_modules/.bin/pragmatist",
@@ -35,7 +36,5 @@
     "build": "npm run pragmatist build",
     "watch": "npm run pragmatist watch"
   },
-  "dependencies": {
-    "lodash": "^3.10.1"
-  }
+  "dependencies": { }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import strictPropTypes from './strictPropTypes';
 
 let decoratorConstructor,
@@ -28,7 +27,7 @@ decoratorConstructor = (options) => {
 };
 
 export default (...args) => {
-    if (_.isFunction(args[0])) {
+    if (typeof args[0] === 'function') {
         return functionConstructor(args[0], args[1]);
     } else {
         return decoratorConstructor(args[0]);

--- a/src/makeConfiguration.js
+++ b/src/makeConfiguration.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 /**
  * @typedef StrictPropTypes~Options
  * @see {@link https://github.com/gajus/react-strict-prop-types#options}
@@ -19,7 +17,11 @@ export default (userConfiguration = {}) => {
         allowSVGProps: false
     };
 
-    _.forEach(userConfiguration, (value, name) => {
+    for (name in userConfiguration){
+        if (!userConfiguration.hasOwnProperty(name)){
+            continue;
+        }
+        let value = userConfiguration[name];
         if (typeof configuration[name] === 'undefined') {
             throw new Error('Unknown configuration property "' + name + '".');
         }
@@ -29,7 +31,7 @@ export default (userConfiguration = {}) => {
         }
 
         configuration[name] = value;
-    });
+    };
 
     return configuration;
 };

--- a/src/strictPropTypes.js
+++ b/src/strictPropTypes.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 
-import _ from 'lodash';
 import HTMLPropNames from './HTMLPropNames';
 import SVGPropNames from './SVGPropNames';
 import makeConfiguration from './makeConfiguration';
@@ -17,23 +16,28 @@ export default (Component, userConfiguration) => {
 
     return class extends Component {
         validateProps (nextProps) {
-            _.forEach(nextProps, (value, name) => {
+            for (let name in nextProps) {
+                if (!nextProps.hasOwnProperty(name)) {
+                    continue;
+                }
+
+                let value = nextProps[name];
                 if (!Component.propTypes[name]) {
                     if (configuration.allowHTMLProps) {
-                        if (_.indexOf(HTMLPropNames, name) !== -1 || _.indexOf(name, 'data-') === 0 || _.indexOf(name, 'aria-') === 0) {
+                        if (HTMLPropNames.indexOf(name) !== -1 || name.indexOf('data-') === 0 || name.indexOf('aria-') === 0) {
                             return;
                         }
                     }
 
                     if (configuration.allowSVGProps) {
-                        if (_.indexOf(SVGPropNames, name) !== -1) {
+                        if (SVGPropNames.indexOf(name) !== -1) {
                             return;
                         }
                     }
 
                     console.warn('Using undefined property "' + name + '". Define the missing property in "' + Component.displayName + '" component propTypes declaration.');
                 }
-            });
+            };
         }
 
         componentWillMount () {

--- a/src/strictPropTypes.js
+++ b/src/strictPropTypes.js
@@ -44,11 +44,11 @@ export default (Component, userConfiguration) => {
             }
         }
 
-        componentWillReceiveProps (nextProps) {
+        componentWillReceiveProps (nextProps, nextContext) {
             this.validateProps(nextProps);
 
             if (super.componentWillReceiveProps) {
-                super.componentWillReceiveProps(nextProps);
+                super.componentWillReceiveProps(nextProps, nextContext);
             }
         }
     };


### PR DESCRIPTION
React's poor documentation for context is probably to blame here.

When a component defines 'contextTypes', componentWillReceiveProps also receives a nextContext parameter, which is otherwise null.

Without this patch, components that implement both context and componentWillReceiveProps stop receiving that extra parameter when strictPropTypes is in use.
